### PR TITLE
Update deps, switch ts runner to 'tsx'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ts-init",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A simple boilerplate generator for TypeScript projects that helps you save time on configuration.",
   "type": "module",
   "license": "MIT",

--- a/template/base/package.json
+++ b/template/base/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@types/node": "^18.15.5",
-    "typescript": "^5.0.2",
+    "@types/node": "^20.4.2",
+    "typescript": "^5.1.6",
     "ts-node": "^10.9.1"
   }
 }

--- a/template/base/package.json
+++ b/template/base/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "start": "node dist/index.js",
-    "dev": "ts-node src/index.ts",
+    "dev": "tsx src/index.ts",
+    "dev:watch": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist"
   },
@@ -12,6 +13,6 @@
   "devDependencies": {
     "@types/node": "^20.4.2",
     "typescript": "^5.1.6",
-    "ts-node": "^10.9.1"
+    "tsx": "^3.12.7"
   }
 }

--- a/template/base/tsconfig.json
+++ b/template/base/tsconfig.json
@@ -12,8 +12,5 @@
     "declaration": true,
     "noEmit": true
   },
-  "ts-node": {
-    "esm": true
-  },
   "exclude": ["node_modules", "dist", "build"]
 }

--- a/template/extra/eslint-prettier/package.json
+++ b/template/extra/eslint-prettier/package.json
@@ -6,10 +6,10 @@
     "lint:fmt": "npm run lint && npm run format"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.55.0",
-    "@typescript-eslint/parser": "^5.55.0",
-    "eslint": "^8.36.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "eslint": "^8.44.0",
     "eslint-config-prettier": "^8.8.0",
-    "prettier": "2.8.4"
+    "prettier": "3.0.0"
   }
 }

--- a/template/extra/jest/package.json
+++ b/template/extra/jest/package.json
@@ -5,8 +5,8 @@
     "test:coverage": "jest --coverage"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.0",
-    "jest": "^29.5.0",
-    "ts-jest": "^29.0.5"
+    "@types/jest": "^29.5.3",
+    "jest": "^29.6.1",
+    "ts-jest": "^29.1.1"
   }
 }


### PR DESCRIPTION
`ts-node` has issues with the latest node version (v20) while `tsx` works out of the box, and supports a nice `watch` command which can benefit dev workflows.